### PR TITLE
Patch for kazoo to pass correct timeout in _invoke. gevent handler takes...

### DIFF
--- a/third_party/kazoo-timeout.diff
+++ b/third_party/kazoo-timeout.diff
@@ -1,0 +1,23 @@
+diff --git a/third_party/kazoo/kazoo/protocol/connection.py b/third_party/kazoo/kazoo/protocol/connection.py
+index e6ad63d..239f9d6 100644
+--- a/third_party/kazoo/kazoo/protocol/connection.py
++++ b/third_party/kazoo/kazoo/protocol/connection.py
+@@ -583,7 +583,7 @@ class ConnectionHandler(object):
+                           client._session_id or 0, client._session_passwd,
+                           client.read_only)
+
+-        connect_result, zxid = self._invoke(client._session_timeout, connect)
++        connect_result, zxid = self._invoke(client._session_timeout / 1000.0, connect)
+
+         if connect_result.time_out <= 0:
+             raise SessionExpiredError("Session has expired")
+@@ -617,7 +617,7 @@ class ConnectionHandler(object):
+
+         for scheme, auth in client.auth_data:
+             ap = Auth(0, scheme, auth)
+-            zxid = self._invoke(connect_timeout, ap, xid=AUTH_XID)
++            zxid = self._invoke(connect_timeout / 1000.0, ap, xid=AUTH_XID)
+             if zxid:
+                 client.last_zxid = zxid
+         return read_timeout, connect_timeout
+

--- a/third_party/packages.xml
+++ b/third_party/packages.xml
@@ -28,6 +28,9 @@
     <url>https://pypi.python.org/packages/source/k/kazoo/kazoo-1.3.1.zip</url>
     <format>zip</format>
     <md5>be826de7afaa7011541fe95dc5238edb</md5>
+    <patches>
+      <patch strip="2">kazoo-timeout.diff</patch>
+    </patches>
     <rename>kazoo</rename>
   </package>
   <package>


### PR DESCRIPTION
... timeout in seconds and kazoo passes the timeout which is multiplied by 1000. This patch ensures that timeout passed to _invoke is divided by 1000.0
